### PR TITLE
Phase 1: Spec persistence to pure JSON (repo layer + template + editor JS + tests)

### DIFF
--- a/core/datastore/repos/spec_version_repo.py
+++ b/core/datastore/repos/spec_version_repo.py
@@ -1,8 +1,9 @@
-from typing import Optional
+from typing import Optional, Any, Dict
 from uuid import UUID
 from datetime import datetime
 from pymongo import DESCENDING
 from core.infra.mongo import get_mongo_db
+import json
 
 class SpecVersionRepo:
     def __init__(self):
@@ -24,13 +25,36 @@ class SpecVersionRepo:
             cursor = cursor.limit(limit)
         return await cursor.to_list(length=limit or 100)
 
-    async def add_version(self, project_id: str, content: str, author: str, diff: Optional[str] = None):
+    def _normalize_content(self, content: Any) -> Dict[str, Any]:
+        if isinstance(content, dict):
+            if "sections" in content and isinstance(content["sections"], list):
+                return content
+            if "content" in content and isinstance(content["content"], str):
+                return {
+                    "sections": [{"name": "raw", "body": content["content"]}],
+                    "meta": {"migratedFrom": "json-content"}
+                }
+        if isinstance(content, str):
+            try:
+                parsed = json.loads(content)
+                return self._normalize_content(parsed)
+            except Exception:
+                return {
+                    "sections": [{"name": "raw", "body": content}],
+                    "meta": {"migratedFrom": "plaintext"}
+                }
+        return {
+            "sections": [{"name": "raw", "body": str(content)}],
+            "meta": {"migratedFrom": "unknown"}
+        }
+
+    async def add_version(self, project_id: str, content: Any, author: str, diff: Optional[str] = None):
         latest = await self.col.find_one({"project_id": project_id}, sort=[("version", DESCENDING)])
         next_version = (latest["version"] + 1) if latest else 1
         return await self.insert({
             "project_id": project_id,
             "version": next_version,
-            "content": content,
+            "content": self._normalize_content(content),
             "author": author,
             "diff": diff
         })

--- a/static/js/spec_editor.js
+++ b/static/js/spec_editor.js
@@ -1,6 +1,19 @@
 let quill = null;
 
-export function initSpecEditor(initialHtml = '') {
+function toInitialHtml(data) {
+  if (typeof data === 'string') return data;
+  if (data && typeof data === 'object') {
+    if (Array.isArray(data.sections) && data.sections.length > 0) {
+      return data.sections[0]?.body || '';
+    }
+    if (typeof data.content === 'string') {
+      return data.content;
+    }
+  }
+  return '';
+}
+
+export function initSpecEditor(initialData = '') {
   const editor = document.getElementById('editor-container');
 
   quill = new Quill(editor, {
@@ -16,10 +29,9 @@ export function initSpecEditor(initialHtml = '') {
     }
   });
 
-  // Load initial content
+  const initialHtml = toInitialHtml(initialData);
   quill.clipboard.dangerouslyPasteHTML(initialHtml);
 
-  // Save button logic
   const saveBtn = document.getElementById('save-spec-btn');
   if (saveBtn) {
     saveBtn.addEventListener('click', () => {

--- a/templates/partials/spec_editor.html
+++ b/templates/partials/spec_editor.html
@@ -9,7 +9,9 @@
 <!-- Quill.js (Rich Text Editor) -->
 <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
 <script src="https://cdn.quilljs.com/1.3.6/quill.min.js" defer></script>
+{{ content|json_script:"spec-data" }}
 <script type="module">
   import { initSpecEditor } from "{% static 'js/spec_editor.js' %}";
-  initSpecEditor(`{{ content|escapejs }}`);
+  const contentData = JSON.parse(document.getElementById('spec-data').textContent);
+  initSpecEditor(contentData);
 </script>

--- a/tests/test_spec_repo_normalize.py
+++ b/tests/test_spec_repo_normalize.py
@@ -1,0 +1,22 @@
+import asyncio
+from core.datastore.repos.spec_version_repo import SpecVersionRepo
+
+def test_normalize_plaintext_to_json():
+    repo = SpecVersionRepo()
+    data = repo._normalize_content("hello world")
+    assert isinstance(data, dict)
+    assert "sections" in data
+    assert data["sections"][0]["body"] == "hello world"
+
+def test_normalize_json_string_passthrough():
+    repo = SpecVersionRepo()
+    s = '{"a": 1, "b": 2}'
+    data = repo._normalize_content(s)
+    assert data["a"] == 1
+    assert data["b"] == 2
+
+def test_normalize_dict_passthrough():
+    repo = SpecVersionRepo()
+    d = {"sections": [{"name": "x", "body": "y"}]}
+    data = repo._normalize_content(d)
+    assert data is d


### PR DESCRIPTION
# Phase 1: Spec persistence to pure JSON (repo layer + template + editor JS + tests)

## Summary
This PR migrates spec content storage from raw HTML/plaintext strings to a standardized JSON format while maintaining backward compatibility and keeping endpoint signatures unchanged. The migration occurs at the repository layer with supporting changes to the template and frontend JavaScript.

**Key Changes:**
- **Repository Layer**: Added `_normalize_content()` method in `SpecVersionRepo` that converts any input (HTML strings, JSON strings, dicts) into a standardized JSON structure with `sections` and `meta` fields
- **Template**: Updated `spec_editor.html` to pass JSON data via Django's `json_script` filter instead of escaped HTML strings
- **Frontend**: Modified `spec_editor.js` to accept JSON input and extract HTML content for the Quill editor
- **Tests**: Added unit tests covering the normalization logic for different input types

The endpoint contracts in `core/endpoints/spec.py` remain unchanged - they still accept and return the same data types, but the underlying storage is now JSON-structured.

## Review & Testing Checklist for Human
- [ ] **End-to-end spec editor functionality**: Create a new spec, edit it, save it, and verify it persists correctly with the new JSON format
- [ ] **Backward compatibility**: Test that existing specs with HTML/plaintext content still display and function correctly after this change
- [ ] **Data integrity**: Verify that the normalization logic doesn't corrupt or lose content, especially for edge cases like nested JSON or special characters
- [ ] **Frontend robustness**: Test the editor with various content types (empty specs, HTML-heavy content, plain text) to ensure the JSON parsing doesn't break the UI
- [ ] **Database inspection**: Check that new spec versions are actually stored in the expected JSON format with `sections` and `meta` fields

**Recommended Test Plan:**
1. Start both services and navigate to a project spec page
2. Create/edit specs with different content types (rich text, plain text, existing content)
3. Inspect the database to verify JSON structure
4. Test with any existing specs to ensure backward compatibility

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["core/endpoints/spec.py<br/>(unchanged)"]:::context --> B["SpecVersionRepo<br/>add_version()"]:::major-edit
    B --> C["_normalize_content()<br/>(new method)"]:::major-edit
    C --> D["MongoDB<br/>(JSON format)"]:::context
    A --> E["templates/partials/<br/>spec_editor.html"]:::major-edit
    E --> F["static/js/<br/>spec_editor.js"]:::major-edit
    F --> G["Quill Editor<br/>(browser)"]:::context
    H["tests/<br/>test_spec_repo_normalize.py"]:::minor-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end


classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes
- The normalization logic handles recursive JSON parsing and multiple input formats, which adds complexity but maintains flexibility
- Endpoint signatures are preserved to avoid breaking changes to the API contract
- The JSON structure uses `sections` array to allow for future multi-section specs while maintaining backward compatibility with single-content specs
- Session: https://app.devin.ai/sessions/e96fb0fd4a8845bfa4fdd81b5a16519c by @Tommyboyjedi