### PR TITLE
Phase 1: Pure JSON persistence at repository layer (UI/endpoints unchanged)

### DIFF
--- a/core/datastore/repos/spec_version_repo.py
+++ b/core/datastore/repos/spec_version_repo.py
@@ -1,36 +1,83 @@
-from typing import Optional
+from typing import Optional, Any, Dict
 from uuid import UUID
 from datetime import datetime
 from pymongo import DESCENDING
 from core.infra.mongo import get_mongo_db
+import json
+
+class _SpecColProxy:
+    def __init__(self, col):
+        self._col = col
+
+    async def find_one(self, *args, **kwargs):
+        doc = await self._col.find_one(*args, **kwargs)
+        if not doc:
+            return doc
+        data = doc.get("content")
+        if isinstance(data, dict):
+            sections = data.get("sections")
+            if isinstance(sections, list) and sections:
+                body = sections[0].get("body")
+                if isinstance(body, str):
+                    doc = dict(doc)
+                    doc["content"] = body
+        return doc
+
+    def __getattr__(self, name):
+        return getattr(self._col, name)
 
 class SpecVersionRepo:
     def __init__(self):
-        self.col = get_mongo_db()["spec_versions"]
+        base_col = get_mongo_db()["spec_versions"]
+        self._col = base_col
+        self.col = _SpecColProxy(base_col)
 
     async def insert(self, doc: dict) -> str:
         doc["created_at"] = doc.get("created_at", datetime.utcnow())
-        result = await self.col.insert_one(doc)
+        result = await self._col.insert_one(doc)
         return str(result.inserted_id)
 
-    async def update(self, filter: dict, update: dict, upsert=False):
-        return await self.col.update_one(filter, {"$set": update}, upsert=upsert)
+    async def update(self, filter: dict, update: dict, upsert: bool = False):
+        return await self._col.update_one(filter, {"$set": update}, upsert=upsert)
 
     async def find(self, filter: dict, sort=None, limit=0):
-        cursor = self.col.find(filter)
+        cursor = self._col.find(filter)
         if sort:
             cursor = cursor.sort(sort)
         if limit:
             cursor = cursor.limit(limit)
         return await cursor.to_list(length=limit or 100)
 
-    async def add_version(self, project_id: str, content: str, author: str, diff: Optional[str] = None):
-        latest = await self.col.find_one({"project_id": project_id}, sort=[("version", DESCENDING)])
+    def _normalize_content(self, content: Any) -> Dict[str, Any]:
+        if isinstance(content, dict):
+            if isinstance(content.get("sections"), list):
+                return content
+            if isinstance(content.get("content"), str):
+                return {
+                    "sections": [{"name": "raw", "body": content["content"]}],
+                    "meta": {"migratedFrom": "json-content"},
+                }
+        if isinstance(content, str):
+            try:
+                parsed = json.loads(content)
+                return self._normalize_content(parsed)
+            except Exception:
+                return {
+                    "sections": [{"name": "raw", "body": content}],
+                    "meta": {"migratedFrom": "plaintext"},
+                }
+        return {
+            "sections": [{"name": "raw", "body": str(content)}],
+            "meta": {"migratedFrom": "unknown"},
+        }
+
+    async def add_version(self, project_id: str, content: Any, author: str, diff: Optional[str] = None):
+        latest = await self._col.find_one({"project_id": project_id}, sort=[("version", DESCENDING)])
         next_version = (latest["version"] + 1) if latest else 1
         return await self.insert({
             "project_id": project_id,
             "version": next_version,
-            "content": content,
+            "content": self._normalize_content(content),
             "author": author,
             "diff": diff
         })

--- a/tests/test_spec_repo_normalize.py
+++ b/tests/test_spec_repo_normalize.py
@@ -1,0 +1,38 @@
+import asyncio
+import json
+from core.datastore.repos.spec_version_repo import SpecVersionRepo, _SpecColProxy
+
+def test_normalize_plaintext_to_json():
+    repo = SpecVersionRepo()
+    data = repo._normalize_content("hello world")
+    assert isinstance(data, dict)
+    assert "sections" in data
+    assert data["sections"][0]["body"] == "hello world"
+
+def test_normalize_json_string_passthrough():
+    repo = SpecVersionRepo()
+    s = json.dumps({"sections": [{"name": "raw", "body": "x"}]})
+    data = repo._normalize_content(s)
+    assert data["sections"][0]["body"] == "x"
+
+def test_normalize_dict_passthrough():
+    repo = SpecVersionRepo()
+    d = {"sections": [{"name": "x", "body": "y"}]}
+    data = repo._normalize_content(d)
+    assert data is d
+
+def test_proxy_find_one_converts_json_content_to_html():
+    class FakeCol:
+        @staticmethod
+        async def find_one(*args, **kwargs):
+            return {
+                "project_id": "p1",
+                "version": 1,
+                "content": {"sections": [{"name": "raw", "body": "<p>hi</p>"}]},
+            }
+
+    proxy = _SpecColProxy(FakeCol())
+    loop = asyncio.get_event_loop()
+    doc = loop.run_until_complete(proxy.find_one({}))
+    assert isinstance(doc.get("content"), str)
+    assert doc["content"] == "<p>hi</p>"


### PR DESCRIPTION
# Phase 1: Pure JSON persistence at repository layer (UI/endpoints unchanged)

## Summary
This PR migrates spec content storage from raw HTML/plaintext strings to a standardized JSON format while maintaining complete backward compatibility and keeping endpoint signatures unchanged. The migration occurs entirely at the repository layer using a proxy pattern.

**Key Changes:**
- **Repository Layer**: Added `_normalize_content()` method in `SpecVersionRepo` that converts any input (HTML strings, JSON strings, dicts) into a standardized JSON structure with `sections` and `meta` fields
- **Backward Compatibility**: Implemented `_SpecColProxy` that intercepts `find_one` calls and automatically converts stored JSON content back to HTML strings for existing code paths
- **Storage Format**: New specs are stored as `{"sections": [{"name": "raw", "body": "<content>"}], "meta": {...}}` while old string content continues to work
- **Tests**: Added unit tests covering the normalization logic and proxy behavior

The endpoint contracts in `core/endpoints/spec.py` remain completely unchanged - they still accept and return the same data types, but the underlying storage is now JSON-structured.

## Review & Testing Checklist for Human
- [ ] **End-to-end spec functionality**: Navigate to a project spec page, create/edit/save specs, and verify they persist correctly with the new JSON storage format
- [ ] **Backward compatibility verification**: Test that any existing specs with HTML/plaintext content still display and function correctly after this change
- [ ] **Database inspection**: Check MongoDB directly to confirm new spec versions are stored in the expected JSON format with `sections` and `meta` fields, while old data remains accessible
- [ ] **Edge case robustness**: Test the editor with various content types (empty specs, HTML-heavy content, special characters, very large content) to ensure the normalization doesn't corrupt data
- [ ] **Proxy behavior validation**: Verify that the `_SpecColProxy` correctly converts JSON content back to HTML strings when accessed through existing code paths

**Recommended Test Plan:**
1. Start both services and navigate to a project spec page
2. Create/edit specs with different content types (rich text, plain text, existing content)
3. Use MongoDB client to inspect the `spec_versions` collection and verify JSON structure
4. Test with any existing specs to ensure backward compatibility

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    EndpointGet["core/endpoints/spec.py<br/>get_spec()"]:::context --> ProxyFindOne["_SpecColProxy<br/>find_one()"]:::major-edit
    EndpointPatch["core/endpoints/spec.py<br/>patch_spec()"]:::context --> RepoAddVersion["SpecVersionRepo<br/>add_version()"]:::major-edit
    RepoAddVersion --> NormalizeContent["_normalize_content()<br/>(new method)"]:::major-edit
    NormalizeContent --> MongoStorage["MongoDB<br/>spec_versions collection<br/>(JSON format)"]:::context
    ProxyFindOne --> MongoStorage
    ProxyFindOne --> HTMLExtraction["Extract HTML from JSON<br/>for backward compat"]:::major-edit
    HTMLExtraction --> SpecTemplate["templates/partials/<br/>spec_editor.html"]:::context
    TestFile["tests/<br/>test_spec_repo_normalize.py"]:::minor-edit
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes
- The proxy pattern allows for transparent migration without touching endpoints or UI code, but adds complexity that should be carefully reviewed
- The normalization logic handles recursive JSON parsing and multiple input formats, which requires thorough testing for edge cases
- This creates a mixed storage state where new content is JSON and old content remains as strings, but the proxy ensures consistent access patterns
- No changes were made to JavaScript, templates, or endpoint signatures per requirements
- **Session**: https://app.devin.ai/sessions/e96fb0fd4a8845bfa4fdd81b5a16519c  
- **Requested by**: Tom Pearce (@Tommyboyjedi)