### PR TITLE
chore(frontend): add HTMX CSRF auto-header utility (no server changes)

### DIFF
--- a/docs/security/csrf.md
+++ b/docs/security/csrf.md
@@ -1,0 +1,13 @@
+# CSRF Protection
+
+The frontend automatically attaches the CSRF token to all HTMX requests.
+
+## How it works
+
+- On page load `static/js/base.js` reads the token from `<meta name="csrf-token">`.
+- If a token is found it registers a global `htmx:configRequest` listener that adds an `X-CSRFToken` header to each HTMX request.
+- If the meta tag is missing, the script does nothing.
+
+## Next steps
+
+When server endpoints are updated to require CSRF validation, existing `csrf_exempt` decorators can be removed safely.

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -8,3 +8,15 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Automatically attach the CSRF token to all HTMX requests.
+    const tokenTag = document.querySelector('meta[name="csrf-token"]');
+    const csrfToken = tokenTag ? tokenTag.getAttribute('content') : null;
+    if (!csrfToken) {
+        return;
+    }
+    document.body.addEventListener('htmx:configRequest', (event) => {
+        event.detail.headers['X-CSRFToken'] = csrfToken;
+    });
+});


### PR DESCRIPTION
## Summary
- auto-attach CSRF token to all HTMX requests via global listener
- document CSRF auto-header behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8839e0570832fb3a88a09f987345f