### PR TITLE
feat(projects): add /api/projects/active JSON endpoint (session-derived)

### DIFF
--- a/core/endpoints/projects.py
+++ b/core/endpoints/projects.py
@@ -1,11 +1,16 @@
 from django.shortcuts import render
-from ninja import Router
+from ninja import Router, Schema
 
 from core.dataclasses.project import Project
 from core.services.project_service import ProjectsService
 
 router = Router(tags=["Projects"])
 ps = ProjectsService()
+
+
+class ActiveProjectResponse(Schema):
+    id: str | None
+    name: str | None
 
 @router.get("/", response=list[Project])
 async def list_projects(request):
@@ -22,6 +27,20 @@ def update_project(request, project_id: str, data: Project):
 @router.get("/{project_id}", response=Project)
 def get_project(request, project_id: str):
     return ps.get_project_by_id(project_id)
+
+
+@router.get("/active/", response=ActiveProjectResponse)
+async def get_active_project(request):
+    project_id = request.session.get("project_id")
+    name = None
+    if project_id:
+        try:
+            project = await ps.get_project_by_id(project_id)
+            if project:
+                name = project.name
+        except Exception:
+            name = None
+    return {"id": project_id, "name": name}
 
 @router.post("/{project_id}/deactivate/")
 async def deactivate_project(request, project_id: str):

--- a/tests/api/test_projects_active.py
+++ b/tests/api/test_projects_active.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import pathlib
+import django
+from django.test import Client, TestCase
+from unittest.mock import AsyncMock, patch
+from django.conf import settings
+
+# Ensure project root on path for imports
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from core.dataclasses.project import Project
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "athba.settings")
+os.environ.setdefault("DJANGO_SECRET_KEY", "test-secret-key")
+os.environ.setdefault("DEBUG", "1")
+os.environ.setdefault("MONGO_USER", "test")
+os.environ.setdefault("MONGO_PASS", "test")
+django.setup()
+
+
+class ActiveProjectEndpointTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    @patch("core.endpoints.projects.ps.get_project_by_id", new_callable=AsyncMock)
+    def test_with_session(self, mock_get):
+        mock_get.return_value = Project(_id="123", name="Test Project")
+        session = self.client.session
+        session["project_id"] = "123"
+        session.save()
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
+
+        response = self.client.get("/api/projects/active/")
+        assert response.status_code == 200
+        assert response.json() == {"id": "123", "name": "Test Project"}
+
+    def test_without_session(self):
+        response = self.client.get("/api/projects/active/")
+        assert response.status_code == 200
+        assert response.json() == {"id": None, "name": None}
+
+    @patch("core.endpoints.projects.ps.get_project_by_id", new_callable=AsyncMock)
+    def test_stale_id(self, mock_get):
+        mock_get.return_value = None
+        session = self.client.session
+        session["project_id"] = "999"
+        session.save()
+        self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
+
+        response = self.client.get("/api/projects/active/")
+        assert response.status_code == 200
+        assert response.json() == {"id": "999", "name": None}


### PR DESCRIPTION
## Summary
- expose GET `/api/projects/active/` returning the session's project id and name
- add unit tests covering session present, missing, and stale project cases

## Testing
- `pytest tests/api/test_projects_active.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88390d6ec832f9f6a7d2df7ca8794