### PR TITLE
PR11: Stabilize ATHBA foundation for Rack AI development

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,25 @@
+name: ATHBA Python gate
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --no-interaction
+      - name: Compile Python
+        run: poetry run python -m compileall athba core llm_service tests
+      - name: Run tests
+        env:
+          CPU_ONLY: 'true'
+        run: poetry run pytest

--- a/core/dataclasses/history_entry.py
+++ b/core/dataclasses/history_entry.py
@@ -5,8 +5,25 @@ from typing import Any
 
 @dataclass
 class HistoryEntry:
+    """Canonical ticket/project history record with legacy constructor compatibility.
+
+    New code should prefer ``event``, ``actor`` and ``details``. ``field/old/new``
+    and ``agent/action`` are retained temporarily so existing persisted records and
+    pre-Rack-AI agent behaviours can be migrated without a flag day.
+    """
+
     timestamp: datetime
-    field: str
-    old: Any
-    new: Any
-    actor: str
+    actor: str = ""
+    event: str = ""
+    details: str = ""
+    field: str = ""
+    old: Any = None
+    new: Any = None
+    agent: str = ""
+    action: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.actor and self.agent:
+            self.actor = self.agent
+        if not self.event and self.action:
+            self.event = self.action

--- a/core/datastore/repos/ticket_repo.py
+++ b/core/datastore/repos/ticket_repo.py
@@ -1,47 +1,87 @@
 # core/repos/ticket_repo.py
 
-from bson import ObjectId
+from dataclasses import asdict
 from datetime import datetime
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
+
+from bson import ObjectId
+
+from core.dataclasses.history_entry import HistoryEntry
 from core.dataclasses.ticket_model import TicketModel
 from core.infra.mongo import get_mongo_db
 
+
 class TicketRepo:
+    """Mongo repository for tickets with one canonical API.
+
+    ``get_ticket_by_id`` and ``update(TicketModel)`` remain as temporary
+    compatibility paths for pre-foundation agent behaviours. New code should use
+    ``get(ticket_id)`` and ``update(ticket_id, updates)``.
+    """
+
     def __init__(self):
         self.col = get_mongo_db().tickets
 
+    @staticmethod
+    def _to_model(doc: dict) -> TicketModel:
+        data = dict(doc)
+        if "_id" in data:
+            data["id"] = str(data.pop("_id"))
+        history = []
+        for entry in data.get("history", []):
+            history.append(HistoryEntry(**entry) if isinstance(entry, dict) else entry)
+        data["history"] = history
+        return TicketModel(**data)
+
+    @staticmethod
+    def _to_document(ticket: TicketModel) -> dict:
+        data = asdict(ticket)
+        data.pop("id", None)
+        return data
+
     async def list_all(self, project_id: str) -> List[TicketModel]:
         docs = await self.col.find({"project_id": project_id}).to_list(length=None)
-        for doc in docs:
-            doc['id'] = str(doc.pop('_id'))
-        return [TicketModel(**doc) for doc in docs]
+        return [self._to_model(doc) for doc in docs]
 
     async def get(self, ticket_id: str) -> Optional[TicketModel]:
         doc = await self.col.find_one({"_id": ObjectId(ticket_id)})
-        if not doc:
-            return None
-        doc['id'] = str(doc.pop('_id'))
-        return TicketModel(**doc)
+        return self._to_model(doc) if doc else None
+
+    async def get_ticket_by_id(self, ticket_id: str) -> Optional[TicketModel]:
+        """Temporary compatibility alias; prefer ``get`` in new code."""
+        return await self.get(ticket_id)
 
     async def create(self, ticket: TicketModel) -> TicketModel:
         now = datetime.utcnow()
-        data = ticket.dict(exclude={"id", "created_at", "updated_at", "history"}, exclude_none=True)
-        data.update({
-            "project_id": ticket.project_id,
-            "created_at": now,
-            "updated_at": now,
-            "history": ticket.history
-        })
-        res = await self.col.insert_one(data)
-        data['id'] = str(res.inserted_id)
-        return TicketModel(**data)
+        data = self._to_document(ticket)
+        data["created_at"] = now
+        data["updated_at"] = now
+        result = await self.col.insert_one(data)
+        data["id"] = str(result.inserted_id)
+        return self._to_model(data)
 
-    async def update(self, ticket_id: str, updates: dict) -> Optional[TicketModel]:
-        updates['updated_at'] = datetime.utcnow()
-        result = await self.col.update_one({"_id": ObjectId(ticket_id)}, {"$set": updates})
-        if result.matched_count:
-            return await self.get(ticket_id)
-        return None
+    async def update(
+        self,
+        ticket_or_id: str | TicketModel,
+        updates: Optional[dict] = None,
+    ) -> Optional[TicketModel]:
+        if isinstance(ticket_or_id, TicketModel):
+            ticket_id = ticket_or_id.id
+            document = self._to_document(ticket_or_id)
+        else:
+            ticket_id = ticket_or_id
+            if updates is None:
+                raise TypeError("updates are required when updating by ticket id")
+            document = dict(updates)
+
+        document.pop("_id", None)
+        document.pop("id", None)
+        document["updated_at"] = datetime.utcnow()
+        result = await self.col.update_one(
+            {"_id": ObjectId(ticket_id)},
+            {"$set": document},
+        )
+        return await self.get(ticket_id) if result.matched_count else None
 
     async def delete(self, ticket_id: str) -> bool:
         result = await self.col.delete_one({"_id": ObjectId(ticket_id)})
@@ -49,24 +89,23 @@ class TicketRepo:
 
     async def batch_update(self, project_id: str, tickets_data: List[Dict]) -> List[TicketModel]:
         existing_docs = await self.col.find({"project_id": project_id}).to_list(length=None)
-        existing_ids = {str(doc['_id']) for doc in existing_docs}
-        incoming_ids = {t['id'] for t in tickets_data if 'id' in t and t['id']}
+        existing_ids = {str(doc["_id"]) for doc in existing_docs}
+        incoming_ids = {ticket["id"] for ticket in tickets_data if ticket.get("id")}
 
-        # Delete removed tickets
-        for tid in existing_ids - incoming_ids:
-            await self.delete(tid)
+        for ticket_id in existing_ids - incoming_ids:
+            await self.delete(ticket_id)
 
         results: List[TicketModel] = []
-        for t in tickets_data:
-            if 'id' in t and t['id'] in existing_ids:
-                tid = t.pop('id')
-                updated = await self.update(tid, t)
+        for raw_ticket in tickets_data:
+            ticket_data = dict(raw_ticket)
+            ticket_id = ticket_data.pop("id", None)
+            if ticket_id and ticket_id in existing_ids:
+                updated = await self.update(ticket_id, ticket_data)
                 if updated:
                     results.append(updated)
             else:
-                model = TicketModel(**t, project_id=project_id)
-                created = await self.create(model)
-                results.append(created)
+                model = TicketModel(**ticket_data, project_id=project_id)
+                results.append(await self.create(model))
         return results
 
     async def count(self, project_id: str, column: Optional[str] = None) -> int:
@@ -78,12 +117,10 @@ class TicketRepo:
     async def assign_ticket(self, ticket_id: str, agents: list[str]) -> bool:
         result = await self.col.update_one(
             {"_id": ObjectId(ticket_id)},
-            {"$set": {"agents": agents, "column": "To Do"}}
+            {"$set": {"agents": agents, "column": "To Do", "updated_at": datetime.utcnow()}},
         )
         return result.modified_count == 1
 
     async def get_backlog_tickets(self, project_id: str) -> list[TicketModel]:
         docs = await self.col.find({"project_id": project_id, "column": "Backlog"}).to_list(length=None)
-        for doc in docs:
-            doc['id'] = str(doc.pop('_id'))
-        return [TicketModel(**doc) for doc in docs]
+        return [self._to_model(doc) for doc in docs]

--- a/core/execution/__init__.py
+++ b/core/execution/__init__.py
@@ -1,0 +1,12 @@
+"""Application ports for external execution and high-value reasoning."""
+
+from core.execution.reasoning_gateway import ReasoningGateway, ReasoningRequest, ReasoningResult
+from core.execution.work_unit_gateway import WorkUnitExecutionGateway, WorkUnitExecutionResult
+
+__all__ = [
+    "ReasoningGateway",
+    "ReasoningRequest",
+    "ReasoningResult",
+    "WorkUnitExecutionGateway",
+    "WorkUnitExecutionResult",
+]

--- a/core/execution/reasoning_gateway.py
+++ b/core/execution/reasoning_gateway.py
@@ -1,0 +1,32 @@
+"""Provider-neutral reasoning boundary for planning and architectural work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class ReasoningRequest:
+    """High-value reasoning request independent of any cloud vendor/model."""
+
+    purpose: str
+    prompt: str
+    project_id: str
+    requires_large_context: bool = False
+
+
+@dataclass(frozen=True)
+class ReasoningResult:
+    """Normalized reasoning response used by ATHBA domain services."""
+
+    text: str
+    provider: str | None = None
+    model: str | None = None
+
+
+class ReasoningGateway(Protocol):
+    """Port for architecture/planning reasoning; OpenRouter is the planned adapter."""
+
+    async def reason(self, request: ReasoningRequest) -> ReasoningResult:
+        ...

--- a/core/execution/work_unit_gateway.py
+++ b/core/execution/work_unit_gateway.py
@@ -1,0 +1,27 @@
+"""Execution boundary between ATHBA and an external work-unit executor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class WorkUnitExecutionResult:
+    """Executor-neutral result returned to the ATHBA application layer."""
+
+    work_unit_id: str
+    accepted: bool
+    status: str
+    change_id: str | None = None
+    branch: str | None = None
+    accepted_revision: str | None = None
+    evidence_location: str | None = None
+
+
+class WorkUnitExecutionGateway(Protocol):
+    """Port implemented by Rack AI adapters and deterministic test fakes."""
+
+    async def execute(self, work_unit: object) -> WorkUnitExecutionResult:
+        """Execute one ready bounded work unit and return structured evidence."""
+        ...

--- a/docs/ATHBA_RACK_AI_ARCHITECTURE.md
+++ b/docs/ATHBA_RACK_AI_ARCHITECTURE.md
@@ -1,0 +1,127 @@
+# ATHBA + Rack AI Architecture
+
+## Decision
+
+ATHBA is the software-development product and development-domain control plane. Rack AI is the rack-wide execution/resource control plane.
+
+ATHBA must be able to turn a user-approved product specification into deliberately small, dependency-aware development work that can be executed by bounded local workers. The small-work-unit/TDD strategy is intentional: it lets comparatively small local models contribute useful implementation work in aggregate. The consequence is that planning, architectural decomposition, acceptance design and replanning become more important, not less.
+
+## Ownership
+
+### ATHBA owns
+- human-facing product development;
+- project specification and architecture;
+- human-level stories/tickets and Kanban state;
+- decomposition into small dependency-aware development work units;
+- TDD strategy and machine-verifiable acceptance requirements;
+- work-unit readiness and project progression;
+- semantic response to failures: clarify, split, reorder, redesign or escalate reasoning;
+- project history, rationale and development memory.
+
+### Rack AI owns
+- rack-wide resource arbitration;
+- GPU, model and worker selection;
+- model/service lifecycle and leases;
+- JCode-backed bounded execution;
+- isolated worktrees, allowed-path enforcement and timeouts;
+- deterministic acceptance execution and evidence capture;
+- fail-closed execution policy.
+
+ATHBA may describe complexity, capability and context needs. It must not name or select a physical GPU, local model or Rack AI worker.
+
+## Human interaction
+
+The end product remains collaborative rather than a batch-only code generator.
+
+The primary interaction surface is a project chat with the Project Manager (PM). The PM is the human-facing conversational coordinator: it helps the user shape the product, edits/refines the live specification, explains proposed changes, requests approvals and reports progress/blockers.
+
+Other specialist agents may contribute internally and their reasoning/results may be surfaced through the PM or read-only project activity views. Direct human chat with every specialist is a future UX choice, not an MVP requirement. The default architecture should avoid forcing the user to decide which agent to address for ordinary product development.
+
+The Tiny Ticket vertical slice does not require the complete chat UX, but the PM/chat boundary is a durable product requirement and must not be designed out of the backend.
+
+## Cloud reasoning gateway
+
+Implementation execution should prefer the local Rack AI path, but high-value planning and architectural reasoning may require a substantially stronger model than the currently available local hardware can provide.
+
+OpenRouter is the default planned cloud reasoning gateway for ATHBA. ATHBA should depend on a provider-neutral reasoning interface, with OpenRouter as the first production adapter rather than embedding a particular upstream model throughout the domain.
+
+Expected cloud-eligible work includes specification synthesis, architecture design/review, decomposition, dependency analysis, acceptance/TDD strategy, difficult semantic replanning and high-context repository analysis.
+
+Cloud use is a development-domain policy decision. It is not a Rack AI worker-selection mechanism. A cloud planner may say that a unit is complex or needs large context; ATHBA still submits capability/complexity requirements to Rack AI without choosing Rack AI's hardware/model.
+
+For the initial Tiny Ticket MVP, the cloud gateway may be mocked or bypassed where deterministic fixtures are sufficient. The interface and architectural intent should nevertheless be preserved from the foundation PR onward.
+
+## Ticket versus work unit
+
+A Kanban ticket is a human/project-management concept. A development work unit is a machine-execution concept.
+
+A single story/ticket may decompose into many deliberately tiny work units. Tiny execution units must not flood the human Kanban board.
+
+```text
+Project
+  -> Story / Ticket
+       -> Work Unit A
+       -> Work Unit B
+       -> Work Unit C
+```
+
+Each work unit should carry only the development information needed to execute and verify one bounded change: objective, allowed paths, deterministic acceptance, dependencies/readiness, capability/complexity/context requirements and bounded limits.
+
+Execution attempts are stored separately from the work-unit definition. ATHBA may record the worker/placement chosen by Rack AI as evidence, but those values are observations only and can never be request inputs.
+
+## TDD
+
+TDD is an ATHBA development strategy, not a Rack AI primitive.
+
+For suitable code work, ATHBA should prefer a narrow RED/GREEN loop: establish one failing test or observable contract; submit the smallest bounded implementation objective; have Rack AI execute deterministic acceptance independently; mark the unit complete only from accepted evidence; unlock dependent work and repeat.
+
+Non-test work may use another machine-verifiable acceptance contract.
+
+## Execution seam
+
+ATHBA domain/application code talks to a `WorkUnitExecutionGateway` abstraction. The first real adapter may invoke Rack AI's `rack-ai/work-unit/v1` CLI with `--emit-json`. Future HTTP/socket transports may replace that adapter without changing the development domain.
+
+## Progression rule
+
+A dependency chain must execute from accepted repository state, not repeatedly from the original base revision.
+
+For sequential work A -> B, the accepted revision produced by A becomes the starting revision for B. Rack AI should expose/promote accepted execution state safely; ATHBA should not manipulate retained Rack AI worktrees as an integration shortcut.
+
+## Delivery sequence
+
+### PR11 — Foundation reset
+- establish this ownership boundary;
+- introduce provider-neutral reasoning and work-unit execution ports;
+- establish a truthful automated test/compile gate;
+- repair domain/repository/test drift before Rack AI integration;
+- retain existing PM/spec/Kanban behaviour.
+
+### PR12 — Work-unit domain + Rack AI adapter
+- add `DevelopmentWorkUnit` and `ExecutionAttempt` domain records;
+- dependency/readiness evaluation;
+- strict `rack-ai/work-unit/v1` serializer/result parser;
+- fake execution gateway for tests;
+- first real Rack AI CLI adapter;
+- prohibit GPU/model/worker identifiers from ATHBA requests.
+
+### PR13 — Tiny Ticket vertical slice
+- add a small development coordinator;
+- execute ready units through Rack AI;
+- consume structured acceptance/evidence;
+- progress dependencies only after acceptance;
+- bounded retry/replan hooks;
+- prove a real Tiny Ticket application through ATHBA -> Rack AI -> JCode.
+
+### Later product work
+- OpenRouter production adapter and configurable cloud reasoning policy;
+- full PM conversational project UX and live specification collaboration;
+- richer architecture/decomposition/replanning;
+- work-unit drill-down beneath human Kanban tickets;
+- development memory and repository intelligence;
+- parallel ready-work pools while Rack AI owns physical scheduling;
+- story/feature integration review and remote Git/PR workflows;
+- evaluation of work-unit size, first-pass success, retries, splits and time-to-green.
+
+## Design principle
+
+Use expensive/strong reasoning where it has the highest leverage: deciding what should be built, how it should be divided, and how success is proved. Use deliberately small bounded work units to make local implementation models productive in aggregate. Keep physical execution/resource policy below ATHBA in Rack AI.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,8 @@ def sample_session():
 def sample_project():
     """Create a sample project for testing."""
     return Project(
-        id="test_project_456",
+        _id="test_project_456",
         name="Test Project",
-        description="A test project",
         active=True,
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow()


### PR DESCRIPTION
## Goal

Reset ATHBA's development foundation so the next integration work is built on a coherent product/domain boundary rather than the legacy in-process execution architecture.

This PR deliberately does **not** implement Tiny Ticket or a live Rack AI call yet.

## Architecture decisions

- ATHBA remains the software-development product and owns specification, architecture, tickets, decomposition, TDD strategy, acceptance design, project progression and semantic replanning.
- Rack AI owns GPU/model/worker choice, JCode execution, isolation, worktrees, acceptance execution, evidence and rack-wide resource policy.
- Human collaboration remains a first-class requirement. The default product surface is a project chat with the PM; specialist agent activity may be surfaced through the PM/read-only project activity rather than requiring the user to choose an agent for normal work.
- High-value planning/architecture may use cloud reasoning. ATHBA should depend on a provider-neutral `ReasoningGateway`; **OpenRouter is the planned default production cloud gateway**.
- Human-level Kanban tickets and machine-level development work units are separate concepts.

## Changes started in this PR

- add `docs/ATHBA_RACK_AI_ARCHITECTURE.md` with the durable boundary and future product requirements;
- add a provider-neutral `ReasoningGateway` seam for architecture/planning work;
- add a provider-neutral `WorkUnitExecutionGateway` seam for the future Rack AI adapter;
- add a Python 3.11 compile/test GitHub Actions gate.

## Remaining implementation required before merge

The branch is intentionally draft until the baseline is truthful. In particular, finish the foundation reset by fixing rather than masking current drift:

- standardize `Project`, `TicketModel` and `HistoryEntry` persistence contracts;
- remove dataclass/Pydantic serialization confusion (`TicketModel` is a dataclass while current repo code calls `.dict()`);
- establish one canonical `TicketRepo` API and repair stale `get_ticket_by_id()` callers;
- repair `LlmEscalationManager` repository/history calls;
- repair stale fixtures such as `Project(id=..., description=...)` against the actual model;
- keep PM/spec/Architect/Kanban behaviour working;
- do not add GPU/model/worker identifiers to ATHBA domain requests.

## Definition of done

- intended ATHBA test suite passes from a clean Python 3.11 environment;
- CI reproduces the same result;
- domain/repository contracts are internally consistent;
- the new execution/reasoning ports remain provider/resource neutral;
- no live Rack AI integration is required in this PR.

## Follow-on stack

- PR12: Development work-unit domain + Rack AI adapter
- PR13: Tiny Ticket ATHBA -> Rack AI -> JCode vertical slice
