### PR TITLE
PR12: Add development work-unit domain and Rack AI adapter

### DIFF
--- a/core/development/__init__.py
+++ b/core/development/__init__.py
@@ -1,0 +1,5 @@
+"""Development-domain types for human tickets and machine work units."""
+
+from core.development.work_unit import AcceptanceContract, DevelopmentWorkUnit, ExecutionAttempt, WorkUnitStatus
+
+__all__ = ["AcceptanceContract", "DevelopmentWorkUnit", "ExecutionAttempt", "WorkUnitStatus"]

--- a/core/development/work_unit.py
+++ b/core/development/work_unit.py
@@ -1,0 +1,57 @@
+"""Domain records for deliberately small development work units."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class WorkUnitStatus(str, Enum):
+    PLANNED = "planned"
+    READY = "ready"
+    RUNNING = "running"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class AcceptanceContract:
+    commands: list[list[str]]
+    required_artifacts: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DevelopmentWorkUnit:
+    id: str
+    project_id: str
+    parent_ticket_id: str
+    objective: str
+    allowed_paths: list[str]
+    acceptance: AcceptanceContract
+    depends_on: list[str] = field(default_factory=list)
+    complexity: str = "small"
+    capability: str = "implementation"
+    requires_large_context: bool = False
+    max_implementation_attempts: int = 2
+    timeout_seconds: int = 900
+    network: str = "disabled"
+    status: WorkUnitStatus = WorkUnitStatus.PLANNED
+
+    def is_ready(self, accepted_dependencies: set[str]) -> bool:
+        """Return true when every declared dependency has been accepted."""
+        return all(dependency in accepted_dependencies for dependency in self.depends_on)
+
+
+@dataclass(frozen=True)
+class ExecutionAttempt:
+    work_unit_id: str
+    accepted: bool
+    status: str
+    change_id: str | None = None
+    selected_worker_id: str | None = None
+    placement: str | None = None
+    branch: str | None = None
+    accepted_revision: str | None = None
+    packet_path: str | None = None
+    error: str | None = None

--- a/core/execution/rack_ai_cli_gateway.py
+++ b/core/execution/rack_ai_cli_gateway.py
@@ -1,0 +1,70 @@
+"""CLI adapter for Rack AI's machine-readable work-unit entry point."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.development.work_unit import DevelopmentWorkUnit
+from core.execution.rack_ai_contract import RepositoryBinding, parse_rack_ai_result, to_rack_ai_request
+from core.execution.work_unit_gateway import WorkUnitExecutionResult
+
+
+@dataclass(frozen=True)
+class RackAiCliConfig:
+    executable: str = "cargo"
+    rack_ai_root: str = "/srv/rack-ai"
+    state_root: str = "/srv/rack-ai"
+
+
+class RackAiCliExecutionGateway:
+    """Invoke Rack AI without leaking worker/model/GPU choices into ATHBA."""
+
+    def __init__(self, workload_id: str, binding: RepositoryBinding, config: RackAiCliConfig | None = None):
+        self.workload_id = workload_id
+        self.binding = binding
+        self.config = config or RackAiCliConfig()
+
+    async def execute(self, work_unit: DevelopmentWorkUnit) -> WorkUnitExecutionResult:
+        payload = to_rack_ai_request(self.workload_id, self.binding, work_unit)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", encoding="utf-8", delete=False) as handle:
+            json.dump(payload, handle)
+            spec_path = Path(handle.name)
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                self.config.executable,
+                "run",
+                "-q",
+                "-p",
+                "rack_ai_cli",
+                "--",
+                "work-unit",
+                str(spec_path),
+                "--repo-root",
+                self.config.rack_ai_root,
+                "--state-root",
+                self.config.state_root,
+                "--emit-json",
+                cwd=self.config.rack_ai_root,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await process.communicate()
+            if not stdout:
+                raise RuntimeError(stderr.decode("utf-8", errors="replace") or "Rack AI returned no JSON")
+            attempt = parse_rack_ai_result(json.loads(stdout.decode("utf-8")))
+            return WorkUnitExecutionResult(
+                work_unit_id=attempt.work_unit_id,
+                accepted=attempt.accepted,
+                status=attempt.status,
+                change_id=attempt.change_id,
+                branch=attempt.branch,
+                accepted_revision=attempt.accepted_revision,
+                evidence_location=attempt.packet_path,
+            )
+        finally:
+            spec_path.unlink(missing_ok=True)

--- a/core/execution/rack_ai_contract.py
+++ b/core/execution/rack_ai_contract.py
@@ -1,0 +1,65 @@
+"""Strict Rack AI work-unit v1 mapping."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.development.work_unit import DevelopmentWorkUnit, ExecutionAttempt
+
+
+CONTRACT_VERSION = "rack-ai/work-unit/v1"
+
+
+@dataclass(frozen=True)
+class RepositoryBinding:
+    repository_id: str
+    base_ref: str
+    base_sha: str
+
+
+def to_rack_ai_request(workload_id: str, binding: RepositoryBinding, unit: DevelopmentWorkUnit) -> dict:
+    return {
+        "version": CONTRACT_VERSION,
+        "workload": {"id": workload_id, "kind": "application-development"},
+        "repository": {
+            "id": binding.repository_id,
+            "base_ref": binding.base_ref,
+            "base_sha": binding.base_sha,
+        },
+        "work_unit": {
+            "id": unit.id,
+            "objective": unit.objective,
+            "allowed_paths": list(unit.allowed_paths),
+            "acceptance": {
+                "commands": [list(command) for command in unit.acceptance.commands],
+                "required_artifacts": list(unit.acceptance.required_artifacts),
+            },
+            "readiness": {"ready": True, "depends_on": list(unit.depends_on)},
+            "requirements": {
+                "capability": unit.capability,
+                "complexity": unit.complexity,
+                "requires_large_context": unit.requires_large_context,
+            },
+            "limits": {
+                "max_implementation_attempts": unit.max_implementation_attempts,
+                "timeout_seconds": unit.timeout_seconds,
+                "network": unit.network,
+            },
+        },
+    }
+
+
+def parse_rack_ai_result(payload: dict) -> ExecutionAttempt:
+    verdict = str(payload.get("acceptance_verdict") or "").lower()
+    return ExecutionAttempt(
+        work_unit_id=payload["work_unit_id"],
+        accepted=verdict == "approved",
+        status=str(payload.get("status", "unknown")),
+        change_id=payload.get("change_id"),
+        selected_worker_id=payload.get("selected_worker_id"),
+        placement=payload.get("placement"),
+        branch=payload.get("branch"),
+        accepted_revision=payload.get("accepted_head_sha") or payload.get("head_sha"),
+        packet_path=payload.get("packet_path"),
+        error=payload.get("last_error"),
+    )

--- a/tests/execution/test_rack_ai_work_unit_contract.py
+++ b/tests/execution/test_rack_ai_work_unit_contract.py
@@ -1,0 +1,37 @@
+from core.development.work_unit import AcceptanceContract, DevelopmentWorkUnit
+from core.execution.rack_ai_contract import RepositoryBinding, to_rack_ai_request
+
+
+def test_work_unit_readiness_requires_all_dependencies():
+    unit = DevelopmentWorkUnit(
+        id="wu-2",
+        project_id="p1",
+        parent_ticket_id="t1",
+        objective="implement one bounded behavior",
+        allowed_paths=["src/app.py"],
+        acceptance=AcceptanceContract(commands=[["pytest", "tests/test_app.py::test_one"]]),
+        depends_on=["wu-1"],
+    )
+    assert not unit.is_ready(set())
+    assert unit.is_ready({"wu-1"})
+
+
+def test_rack_ai_request_never_contains_physical_resource_selection():
+    unit = DevelopmentWorkUnit(
+        id="wu-1",
+        project_id="p1",
+        parent_ticket_id="t1",
+        objective="implement one bounded behavior",
+        allowed_paths=["src/app.py"],
+        acceptance=AcceptanceContract(commands=[["pytest", "tests/test_app.py::test_one"]]),
+    )
+    request = to_rack_ai_request(
+        "p1",
+        RepositoryBinding(repository_id="repo", base_ref="main", base_sha="a" * 40),
+        unit,
+    )
+    serialized = str(request).lower()
+    assert '"gpu"' not in serialized
+    assert '"model"' not in serialized
+    assert '"worker"' not in serialized
+    assert request["version"] == "rack-ai/work-unit/v1"


### PR DESCRIPTION
## Goal

Introduce the machine-execution domain beneath human Kanban tickets and the first strict ATHBA -> Rack AI adapter.

This PR is stacked on PR11.

## Implemented

- `DevelopmentWorkUnit`, `AcceptanceContract`, `ExecutionAttempt` and `WorkUnitStatus` domain records;
- explicit dependency/readiness evaluation;
- strict `rack-ai/work-unit/v1` request mapping;
- structured Rack AI result parsing;
- `RackAiCliExecutionGateway` using Rack AI's `work-unit ... --emit-json` entry point;
- contract tests proving ATHBA does not request a GPU/model/worker.

## Important boundary

ATHBA may request complexity/capability/context characteristics, but physical execution placement remains Rack AI policy.

The adapter intentionally records Rack AI's selected worker/placement only as returned execution evidence.

## Known PR23 dependency

A dependency chain needs accepted repository progression. The parser already accepts `accepted_head_sha`/`head_sha` when Rack AI exposes it, but Rack AI PR23 still needs a safe accepted-revision promotion/progression rule so B can start from accepted A.

## Definition of done

- PR11 is green and merged (or this stacked branch is rebased onto it);
- work-unit contract tests pass;
- the serializer remains compatible with `rack-ai/work-unit/v1`;
- no resource-selection fields leak from ATHBA;
- CLI execution errors are surfaced as structured application failures rather than silently treated as success.
