### PR TITLE
PR13: Add Tiny Ticket ATHBA -> Rack AI coordinator slice

### DIFF
--- a/core/development/coordinator.py
+++ b/core/development/coordinator.py
@@ -1,0 +1,47 @@
+"""Minimal sequential coordinator for the Tiny Ticket proving slice."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from core.development.work_unit import DevelopmentWorkUnit
+from core.execution.work_unit_gateway import WorkUnitExecutionGateway, WorkUnitExecutionResult
+
+
+@dataclass(frozen=True)
+class CoordinationResult:
+    accepted_ids: set[str]
+    attempts: list[WorkUnitExecutionResult]
+    blocked_unit_id: str | None = None
+
+
+class DevelopmentCoordinator:
+    """Advance dependency-aware work one accepted unit at a time.
+
+    Rack AI owns physical execution and retry/resource policy. ATHBA owns whether
+    a rejected unit should later be clarified, split, redesigned or blocked.
+    """
+
+    def __init__(self, gateway: WorkUnitExecutionGateway):
+        self.gateway = gateway
+
+    async def run(self, units: Iterable[DevelopmentWorkUnit]) -> CoordinationResult:
+        pending = list(units)
+        accepted_ids: set[str] = set()
+        attempts: list[WorkUnitExecutionResult] = []
+
+        while pending:
+            ready = next((unit for unit in pending if unit.is_ready(accepted_ids)), None)
+            if ready is None:
+                return CoordinationResult(accepted_ids, attempts, blocked_unit_id=pending[0].id)
+
+            result = await self.gateway.execute(ready)
+            attempts.append(result)
+            if not result.accepted:
+                return CoordinationResult(accepted_ids, attempts, blocked_unit_id=ready.id)
+
+            accepted_ids.add(ready.id)
+            pending.remove(ready)
+
+        return CoordinationResult(accepted_ids, attempts)

--- a/tests/development/test_coordinator.py
+++ b/tests/development/test_coordinator.py
@@ -1,0 +1,53 @@
+import pytest
+
+from core.development.work_unit import AcceptanceContract, DevelopmentWorkUnit
+from core.development.coordinator import DevelopmentCoordinator
+from core.execution.work_unit_gateway import WorkUnitExecutionResult
+
+
+class FakeGateway:
+    def __init__(self, rejected_id=None):
+        self.rejected_id = rejected_id
+        self.calls = []
+
+    async def execute(self, work_unit):
+        self.calls.append(work_unit.id)
+        accepted = work_unit.id != self.rejected_id
+        return WorkUnitExecutionResult(
+            work_unit_id=work_unit.id,
+            accepted=accepted,
+            status="accepted" if accepted else "rejected",
+            accepted_revision=("b" * 40) if accepted else None,
+        )
+
+
+def unit(unit_id, depends_on=None):
+    return DevelopmentWorkUnit(
+        id=unit_id,
+        project_id="tiny-ticket",
+        parent_ticket_id="story-1",
+        objective=f"implement {unit_id}",
+        allowed_paths=["src/app.py"],
+        acceptance=AcceptanceContract(commands=[["pytest", f"tests/test_app.py::{unit_id}"]]),
+        depends_on=depends_on or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_only_runs_dependency_after_acceptance():
+    gateway = FakeGateway()
+    result = await DevelopmentCoordinator(gateway).run([unit("a"), unit("b", ["a"])])
+
+    assert gateway.calls == ["a", "b"]
+    assert result.accepted_ids == {"a", "b"}
+    assert result.blocked_unit_id is None
+
+
+@pytest.mark.asyncio
+async def test_rejected_unit_blocks_progress_instead_of_running_dependents():
+    gateway = FakeGateway(rejected_id="a")
+    result = await DevelopmentCoordinator(gateway).run([unit("a"), unit("b", ["a"])])
+
+    assert gateway.calls == ["a"]
+    assert result.accepted_ids == set()
+    assert result.blocked_unit_id == "a"


### PR DESCRIPTION
## Goal

Add the first dependency-aware development coordinator above the PR12 Rack AI execution gateway.

This PR is stacked on PR12 and intentionally starts **sequentially**. The objective is to prove productive end-to-end progression before adding parallel scheduling.

## Implemented

- `DevelopmentCoordinator` that selects only dependency-ready units;
- progress only after an execution result is accepted;
- rejected work blocks dependents instead of pretending success;
- deterministic fake gateway tests for accepted A -> B progression and rejection blocking.

## Architectural behavior

ATHBA owns semantic reaction to a rejected unit (clarify, split, redesign, reorder, or request stronger planning/reasoning). It does **not** respond by selecting a particular GPU/model/worker.

Rack AI remains responsible for physical execution and evidence.

## Remaining work before this becomes the real Tiny Ticket PASS

- finish/merge PR11 baseline repairs;
- finish/merge PR12 adapter;
- add persistence of work-unit state/execution attempts;
- wire the coordinator into a Tiny Ticket project/story path;
- add an actual Tiny Ticket fixture/repository and deterministic acceptance commands;
- complete the Rack AI PR23 accepted-revision progression mechanism so a dependent unit starts from the accepted revision produced by its prerequisite;
- run the live ATHBA -> Rack AI -> JCode path on gpurack;
- require a real working Tiny Ticket application as the productivity PASS. A safety-only block is not success.

## Definition of done

A real Tiny Ticket build is completed through ATHBA -> Rack AI -> JCode, with evidence retained and dependency progression based only on accepted repository state.
